### PR TITLE
feat: install dfx using dfxvm

### DIFF
--- a/.github/workflows/dfx-action.yml
+++ b/.github/workflows/dfx-action.yml
@@ -2,7 +2,6 @@ on:
   push:
     branches:
       - 'main'
-      - 'ens/dfxvm'
   pull_request:
 
 jobs:

--- a/.github/workflows/dfx-action.yml
+++ b/.github/workflows/dfx-action.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   # This job can be executed locally with the command `act -W .github/workflows/dfx-action.yml`
   test_dfx_action:
-    runs-on: ubuntu-latest
+    runs-on: [ ubuntu-latest, macos-latest ]
     name: Test the dfx action (action.yml)
     strategy:
       matrix:

--- a/.github/workflows/dfx-action.yml
+++ b/.github/workflows/dfx-action.yml
@@ -25,6 +25,7 @@ jobs:
           dfx-version: ${{ matrix.version }}
       - name: Check if the proper dfx version is installed
         run: |
+          export
           actual_dfx_ver="$(dfx --version)"
           expected_dfx_ver="dfx ${{ matrix.version }}"
 

--- a/.github/workflows/dfx-action.yml
+++ b/.github/workflows/dfx-action.yml
@@ -8,11 +8,12 @@ on:
 jobs:
   # This job can be executed locally with the command `act -W .github/workflows/dfx-action.yml`
   test_dfx_action:
-    runs-on: [ ubuntu-latest, macos-latest ]
+    runs-on: ${{ matrix.os }}
     name: Test the dfx action (action.yml)
     strategy:
       matrix:
         version: ['0.11.1', '0.14.1', '0.14.2-beta.2', 'latest']
+        os: [ ubuntu-latest, macos-latest ]
     steps:
       # To use this repository's private action, you must check out the repository
       - name: Checkout

--- a/.github/workflows/dfx-action.yml
+++ b/.github/workflows/dfx-action.yml
@@ -2,6 +2,7 @@ on:
   push:
     branches:
       - 'main'
+      - 'ens/dfxvm'
   pull_request:
 
 jobs:

--- a/.github/workflows/dfx-action.yml
+++ b/.github/workflows/dfx-action.yml
@@ -25,7 +25,6 @@ jobs:
           dfx-version: ${{ matrix.version }}
       - name: Check if the proper dfx version is installed
         run: |
-          export
           actual_dfx_ver="$(dfx --version)"
           expected_dfx_ver="dfx ${{ matrix.version }}"
 

--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ runs:
       run: |
         echo "Version ${{ inputs.dfx-version }} will be installed"
 
-        sh -ci "$(curl -fsSL https://raw.githubusercontent.com/dfinity/sdk/ens/update-setup-dfx-action/public/install-dfxvm.sh)"
+        sh -ci "$(curl -fsSL https://raw.githubusercontent.com/dfinity/sdk/dfxvm-install-script/install.sh)"
     - name: Set up path (linux)
       shell: sh
       if: runner.os == 'Linux'

--- a/action.yml
+++ b/action.yml
@@ -26,4 +26,5 @@ runs:
       shell: sh
       if: runner.os == 'Linux'
       run: |
-        echo "export PATH=\$HOME/.local/share/dfx/bin:\$PATH" >> $GITHUB_ENV
+        echo "$HOME/.local/share/dfx/bin" >> $GITHUB_PATH
+        ls -l $HOME/.local/share/dfx/bin

--- a/action.yml
+++ b/action.yml
@@ -11,14 +11,15 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Set up environment
+    - name: Set DFX_VERSION if not latest
       if: inputs.dfx-version != 'latest'
       shell: sh
       run: |
         echo "DFX_VERSION=${{ inputs.dfx-version }}" >> $GITHUB_ENV
-        echo "DFXVM_INIT_YES=true" >> $GITHUB_ENV
     - name: Install dfx
       shell: sh
+      env:
+        DFXVM_INIT_YES: 'true'
       run: |
         echo "Version ${{ inputs.dfx-version }} will be installed"
         sh -ci "$(curl -fsSL https://raw.githubusercontent.com/dfinity/sdk/ens/update-setup-dfx-action/public/install-dfxvm.sh)"

--- a/action.yml
+++ b/action.yml
@@ -11,12 +11,14 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Set up environment
+      if: inputs.dfx-version != 'latest'
+      shell: sh
+      run: |
+        echo "DFX_VERSION=${{ inputs.dfx-version }}" >> $GITHUB_ENV
+        echo "DFXVM_INIT_YES=true" >> $GITHUB_ENV
     - name: Install dfx
       shell: sh
       run: |
         echo "Version ${{ inputs.dfx-version }} will be installed"
-        if [ "${{ inputs.dfx-version }}" = "latest" ]; then
-          sh -ci "$(curl -fsSL https://internetcomputer.org/install.sh)"
-        else
-          DFX_VERSION="${{ inputs.dfx-version }}" sh -ci "$(curl -fsSL https://internetcomputer.org/install.sh)"
-        fi
+        sh -ci "$(curl -fsSL https://raw.githubusercontent.com/dfinity/sdk/ens/update-setup-dfx-action/public/install-dfxvm.sh)"

--- a/action.yml
+++ b/action.yml
@@ -11,15 +11,19 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Set DFX_VERSION if not latest
-      if: inputs.dfx-version != 'latest'
-      shell: sh
-      run: |
-        echo "DFX_VERSION=${{ inputs.dfx-version }}" >> $GITHUB_ENV
     - name: Install dfx
       shell: sh
       env:
         DFXVM_INIT_YES: 'true'
       run: |
         echo "Version ${{ inputs.dfx-version }} will be installed"
-        sh -ci "$(curl -fsSL https://raw.githubusercontent.com/dfinity/sdk/ens/update-setup-dfx-action/public/install-dfxvm.sh)"
+        if [ "${{ inputs.dfx-version }}" = "latest" ]; then
+          sh -ci "$(curl -fsSL https://raw.githubusercontent.com/dfinity/sdk/ens/update-setup-dfx-action/public/install-dfxvm.sh)"
+        else
+          DFX_VERSION="${{ inputs.dfx-version }}" sh -ci "$(curl -fsSL https://raw.githubusercontent.com/dfinity/sdk/ens/update-setup-dfx-action/public/install-dfxvm.sh)"
+        fi
+    - name: Set up path (linux)
+      shell: sh
+      if: runner.os == 'Linux'
+      run: |
+        echo "export PATH=\$HOME/.local/share/dfx/bin:\$PATH" >> $GITHUB_ENV

--- a/action.yml
+++ b/action.yml
@@ -15,13 +15,10 @@ runs:
       shell: sh
       env:
         DFXVM_INIT_YES: 'true'
-        DFX_VERSION: ${{ inputs.dfx-version != 'latest' && 'abc' || '' }}
+        DFX_VERSION: ${{ inputs.dfx-version != 'latest' && inputs.dfx-version || '' }}
       run: |
         echo "Version ${{ inputs.dfx-version }} will be installed"
 
-#        if [ "${{ inputs.dfx-version }}" != "latest" ]; then
-#          export DFX_VERSION="${{ inputs.dfx-version }}"
-#        fi
         sh -ci "$(curl -fsSL https://raw.githubusercontent.com/dfinity/sdk/ens/update-setup-dfx-action/public/install-dfxvm.sh)"
     - name: Set up path (linux)
       shell: sh

--- a/action.yml
+++ b/action.yml
@@ -15,12 +15,13 @@ runs:
       shell: sh
       env:
         DFXVM_INIT_YES: 'true'
+        DFX_VERSION: ${{ inputs.dfx-version != 'latest' && inputs.dfx-version || '' }}
       run: |
         echo "Version ${{ inputs.dfx-version }} will be installed"
-        
-        if [ "${{ inputs.dfx-version }}" != "latest" ]; then
-          export DFX_VERSION="${{ inputs.dfx-version }}"
-        fi
+
+#        if [ "${{ inputs.dfx-version }}" != "latest" ]; then
+#          export DFX_VERSION="${{ inputs.dfx-version }}"
+#        fi
         sh -ci "$(curl -fsSL https://raw.githubusercontent.com/dfinity/sdk/ens/update-setup-dfx-action/public/install-dfxvm.sh)"
     - name: Set up path (linux)
       shell: sh

--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ runs:
       shell: sh
       env:
         DFXVM_INIT_YES: 'true'
-        DFX_VERSION: ${{ inputs.dfx-version != 'latest' && inputs.dfx-version || '' }}
+        DFX_VERSION: ${{ inputs.dfx-version != 'latest' && 'abc' || '' }}
       run: |
         echo "Version ${{ inputs.dfx-version }} will be installed"
 

--- a/action.yml
+++ b/action.yml
@@ -28,3 +28,8 @@ runs:
       run: |
         echo "$HOME/.local/share/dfx/bin" >> $GITHUB_PATH
         ls -l $HOME/.local/share/dfx/bin
+    - name: Set up path (macos)
+      shell: sh
+      if: runner.os == 'macOS'
+      run: |
+        echo "$HOME/Library/Application Support/org.dfinity.dfx/bin" >> $GITHUB_PATH

--- a/action.yml
+++ b/action.yml
@@ -17,17 +17,16 @@ runs:
         DFXVM_INIT_YES: 'true'
       run: |
         echo "Version ${{ inputs.dfx-version }} will be installed"
-        if [ "${{ inputs.dfx-version }}" = "latest" ]; then
-          sh -ci "$(curl -fsSL https://raw.githubusercontent.com/dfinity/sdk/ens/update-setup-dfx-action/public/install-dfxvm.sh)"
-        else
-          DFX_VERSION="${{ inputs.dfx-version }}" sh -ci "$(curl -fsSL https://raw.githubusercontent.com/dfinity/sdk/ens/update-setup-dfx-action/public/install-dfxvm.sh)"
+        
+        if [ "${{ inputs.dfx-version }}" != "latest" ]; then
+          export DFX_VERSION="${{ inputs.dfx-version }}"
         fi
+        sh -ci "$(curl -fsSL https://raw.githubusercontent.com/dfinity/sdk/ens/update-setup-dfx-action/public/install-dfxvm.sh)"
     - name: Set up path (linux)
       shell: sh
       if: runner.os == 'Linux'
       run: |
         echo "$HOME/.local/share/dfx/bin" >> $GITHUB_PATH
-        ls -l $HOME/.local/share/dfx/bin
     - name: Set up path (macos)
       shell: sh
       if: runner.os == 'macOS'


### PR DESCRIPTION
This will allow this GitHub action to continue to work after we release dfxvm (which will update the install script).

After dfxvm is released, we can change the URL back to https://internetcomputer.org/install.sh

