### PR TITLE
feat: auto mode: inspect dfx.json for dfx version

### DIFF
--- a/.github/workflows/dfx-action.yml
+++ b/.github/workflows/dfx-action.yml
@@ -16,18 +16,6 @@ jobs:
         include:
           - version: '0.11.1'
             expected-version: '0.11.1'
-          - version: '0.14.1'
-            expected-version: '0.14.1'
-          - version: '0.14.2-beta.2'
-            expected-version: '0.14.2-beta.2'
-          - version: 'latest'
-          - version: 'auto'
-          - version: 'auto'
-            dfx-json-dfx-version: '0.11.1'
-            expected-version: '0.11.1'
-          - version: 'auto'
-            dfx-json-dfx-version: '0.14.1'
-            expected-version: '0.14.1'
     steps:
       # To use this repository's private action, you must check out the repository
       - name: Checkout

--- a/.github/workflows/dfx-action.yml
+++ b/.github/workflows/dfx-action.yml
@@ -12,7 +12,6 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-latest ]
-        a: [b, c]
         include:
           - version: '0.11.1'
             expected-version: '0.11.1'

--- a/.github/workflows/dfx-action.yml
+++ b/.github/workflows/dfx-action.yml
@@ -13,20 +13,20 @@ jobs:
       matrix:
         os: [ ubuntu-latest, macos-latest ]
         include:
-            - version: '0.11.1'
-              expected-version: '0.11.1'
-            - version: '0.14.1'
-              expected-version: '0.14.1'
-            - version: '0.14.2-beta.2'
-              expected-version: '0.14.2-beta.2'
-            - version: 'latest'
-            - version: 'auto'
-            - version: 'auto'
-              dfx-json-dfx-version: '0.11.1'
-              expected-version: '0.11.1'
-            - version: 'auto'
-              dfx-json-dfx-version: '0.14.1'
-              expected-version: '0.14.1'
+          - version: '0.11.1'
+            expected-version: '0.11.1'
+          - version: '0.14.1'
+            expected-version: '0.14.1'
+          - version: '0.14.2-beta.2'
+            expected-version: '0.14.2-beta.2'
+          - version: 'latest'
+          - version: 'auto'
+          - version: 'auto'
+            dfx-json-dfx-version: '0.11.1'
+            expected-version: '0.11.1'
+          - version: 'auto'
+            dfx-json-dfx-version: '0.14.1'
+            expected-version: '0.14.1'
     steps:
       # To use this repository's private action, you must check out the repository
       - name: Checkout
@@ -50,7 +50,6 @@ jobs:
           
           actual_dfx_ver="$(dfx --version)"
 
-          # if matrix has an expected-version, check it
           if [ -n "${{ matrix.expected-version }}" ]; then
               expected_dfx_ver="dfx ${{ matrix.expected-version }}"
 
@@ -58,7 +57,8 @@ jobs:
                 echo "Error: expected dfx version '$expected_dfx_ver', but '$actual_dfx_ver' found"
                 exit 1
               fi
-              
+              echo "dfx version '$actual_dfx_ver' was installed correctly"
+          else
+              echo "dfx version '$actual_dfx_ver' was installed"
           fi
 
-          echo "dfx version '$actual_dfx_ver' was installed correctly"

--- a/.github/workflows/dfx-action.yml
+++ b/.github/workflows/dfx-action.yml
@@ -11,7 +11,6 @@ jobs:
     name: Test the dfx action (action.yml)
     strategy:
       matrix:
-        version: ['0.11.1', '0.14.1', '0.14.2-beta.2', 'latest']
         os: [ ubuntu-latest, macos-latest ]
         include:
             - version: '0.11.1'

--- a/.github/workflows/dfx-action.yml
+++ b/.github/workflows/dfx-action.yml
@@ -76,6 +76,7 @@ jobs:
           dfx-version: ${{ matrix.version }}
       - name: Check if the proper dfx version is installed
         run: |
+          pwd
           export
           
           actual_dfx_ver="$(dfx --version)"

--- a/.github/workflows/dfx-action.yml
+++ b/.github/workflows/dfx-action.yml
@@ -18,6 +18,11 @@ jobs:
           - version: '0.14.1'
             expected-version: '0.14.1'
     steps:
+      - name: Debug Matrix
+        run: |
+          echo "Operating System: ${{ matrix.os }}"
+          echo "Version: ${{ matrix.version }}"
+          echo "Expected Version: ${{ matrix.expected-version }}"
       # To use this repository's private action, you must check out the repository
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/dfx-action.yml
+++ b/.github/workflows/dfx-action.yml
@@ -34,6 +34,9 @@ jobs:
             dfx-json-dfx-version: '0.14.1'
             expected-version: '0.14.1'
             os: ubuntu-latest
+          - version: 'auto'
+            dfx-json-no-dfx-version: 'true'
+            os: ubuntu-latest
 
           - version: '0.11.1'
             expected-version: '0.11.1'
@@ -56,6 +59,9 @@ jobs:
             dfx-json-dfx-version: '0.14.1'
             expected-version: '0.14.1'
             os: macos-latest
+          - version: 'auto'
+            dfx-json-no-dfx-version: 'true'
+            os: macos-latest
 
     steps:
       # To use this repository's private action, you must check out the repository
@@ -67,8 +73,12 @@ jobs:
           echo "Testing dfx version ${{ matrix.version }}"
           # create dfx.json with dfx-json-dfx-version if set:
           pwd
-          if [ "${{ matrix.version }}" = "auto" ] && [ -n "${{ matrix.dfx-json-dfx-version }}" ]; then
+          if [ "${{ matrix.version }}" = "auto" ]; then
+            if [ -n "${{ matrix.dfx-json-dfx-version }}" ]; then
               echo "{\"dfx\": \"${{ matrix.dfx-json-dfx-version }}\"}" > dfx.json
+            elif [ -n "${{ matrix.dfx-json-no-dfx-version }}" ]; then
+              echo "{}" > dfx.json
+            fi
           fi
       # Install a certain `dfx` version and check if it is properly installed
       - name: Install dfx

--- a/.github/workflows/dfx-action.yml
+++ b/.github/workflows/dfx-action.yml
@@ -11,12 +11,19 @@ jobs:
     name: Test the dfx action (action.yml)
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest ]
         include:
           - version: '0.11.1'
             expected-version: '0.11.1'
+            os: ubuntu-latest
           - version: '0.14.1'
             expected-version: '0.14.1'
+            os: ubuntu-latest
+          - version: '0.11.1'
+            expected-version: '0.11.1'
+            os: macos-latest
+          - version: '0.14.1'
+            expected-version: '0.14.1'
+            os: macos-latest
     steps:
       - name: Debug Matrix
         run: |

--- a/.github/workflows/dfx-action.yml
+++ b/.github/workflows/dfx-action.yml
@@ -66,7 +66,8 @@ jobs:
           echo "Running on ${{ matrix.os }}"
           echo "Testing dfx version ${{ matrix.version }}"
           # create dfx.json with dfx-json-dfx-version if set:
-          if [ "${{ matrix.version }}" = "auto" && -n "${{ matrix.dfx-json-dfx-version }}" ]; then
+          pwd
+          if [ "${{ matrix.version }}" = "auto" ] && [ -n "${{ matrix.dfx-json-dfx-version }}" ]; then
               echo "{\"dfx\": \"${{ matrix.dfx-json-dfx-version }}\"}" > dfx.json
           fi
       # Install a certain `dfx` version and check if it is properly installed

--- a/.github/workflows/dfx-action.yml
+++ b/.github/workflows/dfx-action.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     name: Test the dfx action (action.yml)
     strategy:
+      fail-fast: false
       matrix:
         include:
           - version: '0.11.1'

--- a/.github/workflows/dfx-action.yml
+++ b/.github/workflows/dfx-action.yml
@@ -13,10 +13,33 @@ jobs:
       matrix:
         version: ['0.11.1', '0.14.1', '0.14.2-beta.2', 'latest']
         os: [ ubuntu-latest, macos-latest ]
+        include:
+            - version: '0.11.1'
+              expected-version: '0.11.1'
+            - version: '0.14.1'
+              expected-version: '0.14.1'
+            - version: '0.14.2-beta.2'
+              expected-version: '0.14.2-beta.2'
+            - version: 'latest'
+            - version: 'auto'
+            - version: 'auto'
+              dfx-json-dfx-version: '0.11.1'
+              expected-version: '0.11.1'
+            - version: 'auto'
+              dfx-json-dfx-version: '0.14.1'
+              expected-version: '0.14.1'
     steps:
       # To use this repository's private action, you must check out the repository
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Setup
+        run: |
+          echo "Running on ${{ matrix.os }}"
+          echo "Testing dfx version ${{ matrix.version }}"
+          # create dfx.jsonb with dfx-json-dfx-version if set:
+          if [ "${{ matrix.version }}" = "auto" ]; then
+              echo "{\"dfx\": \"${{ matrix.dfx-json-dfx-version }}\"}" > dfx.json
+          fi
       # Install a certain `dfx` version and check if it is properly installed
       - name: Install dfx
         uses: ./
@@ -24,16 +47,19 @@ jobs:
           dfx-version: ${{ matrix.version }}
       - name: Check if the proper dfx version is installed
         run: |
+          export
+          
           actual_dfx_ver="$(dfx --version)"
-          expected_dfx_ver="dfx ${{ matrix.version }}"
 
-          if [ "$expected_dfx_ver" != "dfx latest" ]; then
-            if [ "$actual_dfx_ver" != "$expected_dfx_ver" ]; then
-              echo "Error: expected dfx version '$expected_dfx_ver', but '$actual_dfx_ver' found"
-              exit 1
-            fi
+          # if matrix has an expected-version, check it
+          if [ -n "${{ matrix.expected-version }}" ]; then
+              expected_dfx_ver="dfx ${{ matrix.expected-version }}"
 
-            echo "dfx version '$actual_dfx_ver' was installed correctly"
-          else
-            echo "The latest version is '$actual_dfx_ver'"
+              if [ "$actual_dfx_ver" != "$expected_dfx_ver" ]; then
+                echo "Error: expected dfx version '$expected_dfx_ver', but '$actual_dfx_ver' found"
+                exit 1
+              fi
+              
           fi
+
+          echo "dfx version '$actual_dfx_ver' was installed correctly"

--- a/.github/workflows/dfx-action.yml
+++ b/.github/workflows/dfx-action.yml
@@ -18,18 +18,45 @@ jobs:
           - version: '0.14.1'
             expected-version: '0.14.1'
             os: ubuntu-latest
+          - version: '0.14.2-beta.2'
+            expected-version: '0.14.2-beta.2'
+            os: ubuntu-latest
+          - version: 'latest'
+            os: ubuntu-latest
+          - version: 'auto'
+            os: ubuntu-latest
+          - version: 'auto'
+            dfx-json-dfx-version: '0.11.1'
+            expected-version: '0.11.1'
+            os: ubuntu-latest
+          - version: 'auto'
+            dfx-json-dfx-version: '0.14.1'
+            expected-version: '0.14.1'
+            os: ubuntu-latest
+
           - version: '0.11.1'
             expected-version: '0.11.1'
             os: macos-latest
           - version: '0.14.1'
             expected-version: '0.14.1'
             os: macos-latest
+          - version: '0.14.2-beta.2'
+            expected-version: '0.14.2-beta.2'
+            os: macos-latest
+          - version: 'latest'
+            os: macos-latest
+          - version: 'auto'
+            os: macos-latest
+          - version: 'auto'
+            dfx-json-dfx-version: '0.11.1'
+            expected-version: '0.11.1'
+            os: macos-latest
+          - version: 'auto'
+            dfx-json-dfx-version: '0.14.1'
+            expected-version: '0.14.1'
+            os: macos-latest
+
     steps:
-      - name: Debug Matrix
-        run: |
-          echo "Operating System: ${{ matrix.os }}"
-          echo "Version: ${{ matrix.version }}"
-          echo "Expected Version: ${{ matrix.expected-version }}"
       # To use this repository's private action, you must check out the repository
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/dfx-action.yml
+++ b/.github/workflows/dfx-action.yml
@@ -12,6 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-latest ]
+        a: [b, c]
         include:
           - version: '0.11.1'
             expected-version: '0.11.1'

--- a/.github/workflows/dfx-action.yml
+++ b/.github/workflows/dfx-action.yml
@@ -37,6 +37,13 @@ jobs:
           - version: 'auto'
             dfx-json-no-dfx-version: 'true'
             os: ubuntu-latest
+          - version: 'latest'
+            os: ubuntu-latest
+            dfx-json-dfx-version: '0.14.1'
+          - version: '0.14.1'
+            expected-version: '0.14.1'
+            dfx-json-dfx-version: '0.13.1'
+            os: ubuntu-latest
 
           - version: '0.11.1'
             expected-version: '0.11.1'
@@ -62,6 +69,13 @@ jobs:
           - version: 'auto'
             dfx-json-no-dfx-version: 'true'
             os: macos-latest
+          - version: 'latest'
+            os: macos-latest
+            dfx-json-dfx-version: '0.14.1'
+          - version: '0.14.1'
+            expected-version: '0.14.1'
+            dfx-json-dfx-version: '0.13.1'
+            os: macos-latest
 
     steps:
       # To use this repository's private action, you must check out the repository
@@ -69,16 +83,10 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup
         run: |
-          echo "Running on ${{ matrix.os }}"
-          echo "Testing dfx version ${{ matrix.version }}"
-          # create dfx.json with dfx-json-dfx-version if set:
-          pwd
-          if [ "${{ matrix.version }}" = "auto" ]; then
-            if [ -n "${{ matrix.dfx-json-dfx-version }}" ]; then
-              echo "{\"dfx\": \"${{ matrix.dfx-json-dfx-version }}\"}" > dfx.json
-            elif [ -n "${{ matrix.dfx-json-no-dfx-version }}" ]; then
-              echo "{}" > dfx.json
-            fi
+          if [ -n "${{ matrix.dfx-json-dfx-version }}" ]; then
+            echo "{\"dfx\": \"${{ matrix.dfx-json-dfx-version }}\"}" > dfx.json
+          elif [ -n "${{ matrix.dfx-json-no-dfx-version }}" ]; then
+            echo "{}" > dfx.json
           fi
       # Install a certain `dfx` version and check if it is properly installed
       - name: Install dfx
@@ -87,9 +95,6 @@ jobs:
           dfx-version: ${{ matrix.version }}
       - name: Check if the proper dfx version is installed
         run: |
-          pwd
-          export
-          
           actual_dfx_ver="$(dfx --version)"
 
           if [ -n "${{ matrix.expected-version }}" ]; then
@@ -103,4 +108,3 @@ jobs:
           else
               echo "dfx version '$actual_dfx_ver' was installed"
           fi
-

--- a/.github/workflows/dfx-action.yml
+++ b/.github/workflows/dfx-action.yml
@@ -16,6 +16,8 @@ jobs:
         include:
           - version: '0.11.1'
             expected-version: '0.11.1'
+          - version: '0.14.1'
+            expected-version: '0.14.1'
     steps:
       # To use this repository's private action, you must check out the repository
       - name: Checkout

--- a/.github/workflows/dfx-action.yml
+++ b/.github/workflows/dfx-action.yml
@@ -64,8 +64,8 @@ jobs:
         run: |
           echo "Running on ${{ matrix.os }}"
           echo "Testing dfx version ${{ matrix.version }}"
-          # create dfx.jsonb with dfx-json-dfx-version if set:
-          if [ "${{ matrix.version }}" = "auto" ]; then
+          # create dfx.json with dfx-json-dfx-version if set:
+          if [ "${{ matrix.version }}" = "auto" && -n "${{ matrix.dfx-json-dfx-version }}" ]; then
               echo "{\"dfx\": \"${{ matrix.dfx-json-dfx-version }}\"}" > dfx.json
           fi
       # Install a certain `dfx` version and check if it is properly installed

--- a/.github/workflows/dfx-action.yml
+++ b/.github/workflows/dfx-action.yml
@@ -37,13 +37,6 @@ jobs:
           - version: 'auto'
             dfx-json-no-dfx-version: 'true'
             os: ubuntu-latest
-          - version: 'latest'
-            os: ubuntu-latest
-            dfx-json-dfx-version: '0.14.1'
-          - version: '0.14.1'
-            expected-version: '0.14.1'
-            dfx-json-dfx-version: '0.13.1'
-            os: ubuntu-latest
 
           - version: '0.11.1'
             expected-version: '0.11.1'
@@ -68,13 +61,6 @@ jobs:
             os: macos-latest
           - version: 'auto'
             dfx-json-no-dfx-version: 'true'
-            os: macos-latest
-          - version: 'latest'
-            os: macos-latest
-            dfx-json-dfx-version: '0.14.1'
-          - version: '0.14.1'
-            expected-version: '0.14.1'
-            dfx-json-dfx-version: '0.13.1'
             os: macos-latest
 
     steps:

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ You can specify a particular version of dfx to install using the `dfx-version` i
 
 | Input         | Description   |
 |---------------|---------------|
-| `dfx-version` | (Optional) The version of dfx to install. If not specified, the latest version will be installed.
+| `dfx-version` | (Optional) The version of dfx to install. If "auto" (the default), the version will be taken from dfx.json if present, otherwise latest.  If "latest", the latest version will be installed.
 
 ## Contributing
 

--- a/action.yml
+++ b/action.yml
@@ -22,19 +22,21 @@ runs:
             echo "Latest version will be installed"
             export DFX_VERSION=""
         elif [ "${{ inputs.dfx-version }}" = "auto" ]; then
-            if [ -f dfx.json ]; then
-                export DFX_VERSION="$(jq -r '.dfx // ""' dfx.json)"
-                echo "Took DFX_VERSION=$DFX_VERSION from dfx.json"
-            else
-                echo "No dfx.json found, installing the latest version"
-                export DFX_VERSION=""
-            fi
+            export DFX_VERSION="$(jq -er '.dfx // ""' dfx.json || echo "")"
+            echo "Took DFX_VERSION=$DFX_VERSION from dfx.json"
+#            if [ -f dfx.json ]; then
+#                export DFX_VERSION="$(jq -r '.dfx // ""' dfx.json)"
+#                echo "Took DFX_VERSION=$DFX_VERSION from dfx.json"
+#            else
+#                echo "No dfx.json found, installing the latest version"
+#                export DFX_VERSION=""
+#            fi
         else
             export DFX_VERSION="${{ inputs.dfx-version }}"
         fi
-        
+
         echo "DFX_VERSION is $DFX_VERSION"
-        
+
         sh -ci "$(curl -fsSL https://internetcomputer.org/install.sh)"
     - name: Set up path (linux)
       shell: sh

--- a/action.yml
+++ b/action.yml
@@ -24,13 +24,13 @@ runs:
         elif [ "${{ inputs.dfx-version }}" = "auto" ]; then
             export DFX_VERSION="$(jq -er '.dfx // ""' dfx.json || echo "")"
             echo "Took DFX_VERSION=$DFX_VERSION from dfx.json"
-#            if [ -f dfx.json ]; then
-#                export DFX_VERSION="$(jq -r '.dfx // ""' dfx.json)"
-#                echo "Took DFX_VERSION=$DFX_VERSION from dfx.json"
-#            else
-#                echo "No dfx.json found, installing the latest version"
-#                export DFX_VERSION=""
-#            fi
+            #            if [ -f dfx.json ]; then
+            #                export DFX_VERSION="$(jq -r '.dfx // ""' dfx.json)"
+            #                echo "Took DFX_VERSION=$DFX_VERSION from dfx.json"
+            #            else
+            #                echo "No dfx.json found, installing the latest version"
+            #                export DFX_VERSION=""
+            #            fi
         else
             export DFX_VERSION="${{ inputs.dfx-version }}"
         fi

--- a/action.yml
+++ b/action.yml
@@ -17,17 +17,14 @@ runs:
       shell: sh
       env:
         DFXVM_INIT_YES: 'true'
-        # DFX_VERSION: ${{ inputs.dfx-version != 'latest' && inputs.dfx-version || '' }}
       run: |
-        echo "ACTION_RUNNING_IN=$(pwd)" >> $GITHUB_ENV
         if [ "${{ inputs.dfx-version }}" = "latest" ]; then
             echo "Latest version will be installed"
             export DFX_VERSION=""
         elif [ "${{ inputs.dfx-version }}" = "auto" ]; then
             if [ -f dfx.json ]; then
-                export DFX_VERSION="$(jq -r '.dfx' dfx.json)"
-                echo "ACTION_DFX_JSON_VERSION=$DFX_VERSION" >> $GITHUB_ENV
-                echo "Version $DFX_VERSION from dfx.json will be installed"
+                export DFX_VERSION="$(jq -r '.dfx // ""' dfx.json)"
+                echo "Took $DFX_VERSION='$DFX_VERSION' from dfx.json"
             else
                 echo "ACTION_NO_DFX_JSON=true" >> $GITHUB_ENV
                 echo "No dfx.json found, installing the latest version"

--- a/action.yml
+++ b/action.yml
@@ -26,8 +26,10 @@ runs:
         elif [ "${{ inputs.dfx-version }}" = "auto" ]; then
             if [ -f dfx.json ]; then
                 export DFX_VERSION="$(jq -r '.dfx' dfx.json)"
+                echo "ACTION_DFX_JSON_VERSION=$DFX_VERSION" >> $GITHUB_ENV
                 echo "Version $DFX_VERSION from dfx.json will be installed"
             else
+                echo "ACTION_NO_DFX_JSON=true" >> $GITHUB_ENV
                 echo "No dfx.json found, installing the latest version"
                 export DFX_VERSION=""
             fi

--- a/action.yml
+++ b/action.yml
@@ -24,9 +24,8 @@ runs:
         elif [ "${{ inputs.dfx-version }}" = "auto" ]; then
             if [ -f dfx.json ]; then
                 export DFX_VERSION="$(jq -r '.dfx // ""' dfx.json)"
-                echo "Took $DFX_VERSION='$DFX_VERSION' from dfx.json"
+                echo "Took DFX_VERSION=$DFX_VERSION from dfx.json"
             else
-                echo "ACTION_NO_DFX_JSON=true" >> $GITHUB_ENV
                 echo "No dfx.json found, installing the latest version"
                 export DFX_VERSION=""
             fi

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,7 @@ runs:
         DFXVM_INIT_YES: 'true'
         # DFX_VERSION: ${{ inputs.dfx-version != 'latest' && inputs.dfx-version || '' }}
       run: |
+        brew install jq
         if [ "${{ inputs.dfx-version }}" = "latest" ]; then
             echo "Latest version will be installed"
             export DFX_VERSION=""
@@ -33,6 +34,8 @@ runs:
         else
             export DFX_VERSION="${{ inputs.dfx-version }}"
         fi
+        
+        echo "DFX_VERSION is $DFX_VERSION"
         
         sh -ci "$(curl -fsSL https://internetcomputer.org/install.sh)"
     - name: Set up path (linux)

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,9 @@ inputs:
       The dfx version to install. This value will be used to populate
       the DFX_VERSION variable that will be handled by the installation
       script "install.sh".
-    default: 'latest'
+      If "latest" is provided, the latest version will be installed.
+      If "auto" is provided, the version will be taken from the "dfx" field in dfx.json if it exists; otherwise as if "latest".
+    default: 'auto'
 
 runs:
   using: composite
@@ -15,10 +17,24 @@ runs:
       shell: sh
       env:
         DFXVM_INIT_YES: 'true'
-        DFX_VERSION: ${{ inputs.dfx-version != 'latest' && inputs.dfx-version || '' }}
+        # DFX_VERSION: ${{ inputs.dfx-version != 'latest' && inputs.dfx-version || '' }}
       run: |
-        echo "Version ${{ inputs.dfx-version }} will be installed"
-
+        # if the version is "auto", check if dfx.json exists and use the version from it
+        if [ "${{ inputs.dfx-version }}" = "auto" ]; then
+            if [ -f dfx.json ]; then
+                export DFX_VERSION="$(jq -r '.dfx' dfx.json)"
+                echo "Version $DFX_VERSION will be installed"
+            else
+                echo "No dfx.json found, installing the latest version"
+                DFX_VERSION=""
+            fi
+        fi
+        # if the version is neither "latest" not "auto", export it to the environment
+        if [ "${{ inputs.dfx-version }}" != "latest" ] && [ "${{ inputs.dfx-version }}" != "auto" ]; then
+            echo "Version $DFX_VERSION will be installed"
+            export DFX_VERSION="${{ inputs.dfx-version }}"
+        fi
+        
         sh -ci "$(curl -fsSL https://internetcomputer.org/install.sh)"
     - name: Set up path (linux)
       shell: sh

--- a/action.yml
+++ b/action.yml
@@ -13,13 +13,20 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Install jq (Linux)
+      if: runner.os == 'Linux'
+      shell: sh
+      run: sudo apt-get install jq
+    - name: Install jq (macos)
+      if: runner.os == 'macOS'
+      shell: sh
+      run: brew install jq
     - name: Install dfx
       shell: sh
       env:
         DFXVM_INIT_YES: 'true'
         # DFX_VERSION: ${{ inputs.dfx-version != 'latest' && inputs.dfx-version || '' }}
       run: |
-        brew install jq
         if [ "${{ inputs.dfx-version }}" = "latest" ]; then
             echo "Latest version will be installed"
             export DFX_VERSION=""

--- a/action.yml
+++ b/action.yml
@@ -19,20 +19,11 @@ runs:
         DFXVM_INIT_YES: 'true'
       run: |
         if [ "${{ inputs.dfx-version }}" = "latest" ]; then
-            echo "Latest version will be installed"
-            export DFX_VERSION=""
+          export DFX_VERSION=""
         elif [ "${{ inputs.dfx-version }}" = "auto" ]; then
-            export DFX_VERSION="$(jq -er '.dfx // ""' dfx.json || echo "")"
-            echo "Took DFX_VERSION=$DFX_VERSION from dfx.json"
-            #            if [ -f dfx.json ]; then
-            #                export DFX_VERSION="$(jq -r '.dfx // ""' dfx.json)"
-            #                echo "Took DFX_VERSION=$DFX_VERSION from dfx.json"
-            #            else
-            #                echo "No dfx.json found, installing the latest version"
-            #                export DFX_VERSION=""
-            #            fi
+          export DFX_VERSION="$(jq -er '.dfx // ""' dfx.json || echo "")"
         else
-            export DFX_VERSION="${{ inputs.dfx-version }}"
+          export DFX_VERSION="${{ inputs.dfx-version }}"
         fi
 
         echo "DFX_VERSION is $DFX_VERSION"

--- a/action.yml
+++ b/action.yml
@@ -19,19 +19,18 @@ runs:
         DFXVM_INIT_YES: 'true'
         # DFX_VERSION: ${{ inputs.dfx-version != 'latest' && inputs.dfx-version || '' }}
       run: |
-        # if the version is "auto", check if dfx.json exists and use the version from it
-        if [ "${{ inputs.dfx-version }}" = "auto" ]; then
+        if [ "${{ inputs.dfx-version }}" = "latest" ]; then
+            echo "Latest version will be installed"
+            export DFX_VERSION=""
+        elif [ "${{ inputs.dfx-version }}" = "auto" ]; then
             if [ -f dfx.json ]; then
                 export DFX_VERSION="$(jq -r '.dfx' dfx.json)"
-                echo "Version $DFX_VERSION will be installed"
+                echo "Version $DFX_VERSION from dfx.json will be installed"
             else
                 echo "No dfx.json found, installing the latest version"
-                DFX_VERSION=""
+                export DFX_VERSION=""
             fi
-        fi
-        # if the version is neither "latest" not "auto", export it to the environment
-        if [ "${{ inputs.dfx-version }}" != "latest" ] && [ "${{ inputs.dfx-version }}" != "auto" ]; then
-            echo "Version $DFX_VERSION will be installed"
+        else
             export DFX_VERSION="${{ inputs.dfx-version }}"
         fi
         

--- a/action.yml
+++ b/action.yml
@@ -13,20 +13,13 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Install jq (Linux)
-      if: runner.os == 'Linux'
-      shell: sh
-      run: sudo apt-get install jq
-    - name: Install jq (macos)
-      if: runner.os == 'macOS'
-      shell: sh
-      run: brew install jq
     - name: Install dfx
       shell: sh
       env:
         DFXVM_INIT_YES: 'true'
         # DFX_VERSION: ${{ inputs.dfx-version != 'latest' && inputs.dfx-version || '' }}
       run: |
+        echo "ACTION_RUNNING_IN=$(pwd)" >> $GITHUB_ENV
         if [ "${{ inputs.dfx-version }}" = "latest" ]; then
             echo "Latest version will be installed"
             export DFX_VERSION=""


### PR DESCRIPTION
Some were jumping through some hoops to read the dfx version from dfx.json in order to use the setup-dfx action, for example t https://github.com/dfinity/nns-dapp/blob/105b91f4c70440104c8cdb5d72c69c708632e24d/.github/workflows/checks.yml#L172C1-L177C46:
```
      - name: Get dfx version
        run: echo "DFX_VERSION=$(jq -r .dfx dfx.json)" >> $GITHUB_ENV
      - name: Install dfx
        uses: dfinity/setup-dfx@main
        with:
          dfx-version: ${{ env.DFX_VERSION }}
```

This PR introduces a new `auto` option for `version`, which is the new default.  For `auto`, if there is a dfx.json and it has a `dfx` field, install that dfx version.  Otherwise, treat it the same as `latest`.
