### PR TITLE
fix: curl on ubuntu-20.04 does not support --retry-all-errors

### DIFF
--- a/.github/workflows/dfx-action.yml
+++ b/.github/workflows/dfx-action.yml
@@ -19,6 +19,18 @@ jobs:
           - version: '0.11.1'
             expected-version: '0.11.1'
             os: ubuntu-22.04
+          - version: '0.11.1'
+            expected-version: '0.11.1'
+            os: macos-11
+          - version: '0.11.1'
+            expected-version: '0.11.1'
+            os: macos-12
+          - version: '0.11.1'
+            expected-version: '0.11.1'
+            os: macos-13
+          - version: '0.11.1'
+            expected-version: '0.11.1'
+            os: macos-14
 
           - version: '0.11.1'
             expected-version: '0.11.1'

--- a/.github/workflows/dfx-action.yml
+++ b/.github/workflows/dfx-action.yml
@@ -15,6 +15,13 @@ jobs:
         include:
           - version: '0.11.1'
             expected-version: '0.11.1'
+            os: ubuntu-20.04
+          - version: '0.11.1'
+            expected-version: '0.11.1'
+            os: ubuntu-22.04
+
+          - version: '0.11.1'
+            expected-version: '0.11.1'
             os: ubuntu-latest
           - version: '0.14.1'
             expected-version: '0.14.1'

--- a/action.yml
+++ b/action.yml
@@ -30,7 +30,7 @@ runs:
 
         # Retry up to 10 times.  Each attempt has 20 seconds total to complete, 5 seconds of which is to connect.
         # This uses the default retry delay, which starts at 1s and doubles each time, up to 10 min.
-        if install_script=$(curl --fail --silent --show-error --location --retry 10 --connect-timeout 5 --max-time 20 --retry-all-errors --retry-connrefused  https://internetcomputer.org/install.sh); then
+        if install_script=$(curl --fail --silent --show-error --location --retry 10 --connect-timeout 5 --max-time 20 --retry-connrefused  https://internetcomputer.org/install.sh); then
           sh -c "$install_script"
         else
           echo "Failed to download install script."


### PR DESCRIPTION
Removed the `--retry-all-errors` option, since it's not supported on the curl bundled in ubuntu-20.04.

Also added version-specific tests for ubuntu-20.04 and ubuntu-22.04 and macos-11 through macos-14.
